### PR TITLE
Fix: Use GenerationType.IDENTITY for MySQL compatibility

### DIFF
--- a/src/main/java/uy/com/bay/cruds/data/AbstractEntity.java
+++ b/src/main/java/uy/com/bay/cruds/data/AbstractEntity.java
@@ -11,9 +11,7 @@ import jakarta.persistence.Version;
 public abstract class AbstractEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "idgenerator")
-    // The initial value is to account for data.sql demo data ids
-    @SequenceGenerator(name = "idgenerator", initialValue = 1000)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Version


### PR DESCRIPTION
Changed JPA ID generation strategy in AbstractEntity from SEQUENCE to IDENTITY. This resolves an SQLSyntaxErrorException caused by Hibernate generating MySQL-incompatible SQL for sequence-based ID generation.

The @SequenceGenerator annotation was removed as it's no longer needed with GenerationType.IDENTITY. I reviewed data.sql, which is empty, ensuring no conflicts with pre-populated data.