### PR TITLE
feat: Añadir endpoints REST para Proyectos y Encuestadores

### DIFF
--- a/src/main/java/uy/com/bay/cruds/controllers/EncuestadorController.java
+++ b/src/main/java/uy/com/bay/cruds/controllers/EncuestadorController.java
@@ -1,0 +1,25 @@
+package uy.com.bay.cruds.controllers;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uy.com.bay.cruds.data.Encuestador;
+import uy.com.bay.cruds.services.EncuestadorService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/encuestadores")
+public class EncuestadorController {
+
+    private final EncuestadorService encuestadorService;
+
+    public EncuestadorController(EncuestadorService encuestadorService) {
+        this.encuestadorService = encuestadorService;
+    }
+
+    @GetMapping
+    public List<Encuestador> getAllEncuestadores() {
+        return encuestadorService.findAll();
+    }
+}

--- a/src/main/java/uy/com/bay/cruds/controllers/ProyectoController.java
+++ b/src/main/java/uy/com/bay/cruds/controllers/ProyectoController.java
@@ -1,0 +1,27 @@
+package uy.com.bay.cruds.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uy.com.bay.cruds.data.Proyecto;
+import uy.com.bay.cruds.services.ProyectoService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/proyectos")
+public class ProyectoController {
+
+    private final ProyectoService proyectoService;
+
+    // Inyección por constructor (preferida)
+    public ProyectoController(ProyectoService proyectoService) {
+        this.proyectoService = proyectoService;
+    }
+
+    @GetMapping
+    public List<Proyecto> getAllProyectos() {
+        return proyectoService.findAll();
+    }
+}

--- a/src/main/java/uy/com/bay/cruds/services/EncuestadorService.java
+++ b/src/main/java/uy/com/bay/cruds/services/EncuestadorService.java
@@ -1,5 +1,6 @@
 package uy.com.bay.cruds.services;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -41,4 +42,7 @@ public class EncuestadorService {
         return (int) repository.count();
     }
 
+    public List<Encuestador> findAll() {
+        return repository.findAll();
+    }
 }

--- a/src/main/java/uy/com/bay/cruds/services/ProyectoService.java
+++ b/src/main/java/uy/com/bay/cruds/services/ProyectoService.java
@@ -1,5 +1,6 @@
 package uy.com.bay.cruds.services;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -41,4 +42,7 @@ public class ProyectoService {
         return (int) repository.count();
     }
 
+    public List<Proyecto> findAll() {
+        return repository.findAll();
+    }
 }


### PR DESCRIPTION
Se han creado dos nuevos controladores REST:

1.  `ProyectoController` en `/api/proyectos`:
    - Expone un endpoint GET para obtener una lista de todos los proyectos.
    - Se añadió un método `findAll()` a `ProyectoService` para soportar esto.

2.  `EncuestadorController` en `/api/encuestadores`:
    - Expone un endpoint GET para obtener una lista de todos los encuestadores.
    - Se añadió un método `findAll()` a `EncuestadorService` para soportar esto.

Estos endpoints devuelven los datos en formato JSON.