### PR TITLE
feat: Gestionar visibilidad de paneles de edición en Vistas CRUD

### DIFF
--- a/src/main/java/uy/com/bay/cruds/views/encuestadores/EncuestadoresView.java
+++ b/src/main/java/uy/com/bay/cruds/views/encuestadores/EncuestadoresView.java
@@ -55,6 +55,7 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
     private final BeanValidationBinder<Encuestador> binder;
 
     private Encuestador encuestador;
+    private Div editorLayoutDiv; // Added field declaration
 
     private final EncuestadorService encuestadorService;
 
@@ -69,11 +70,13 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
         addButton = new Button("Agregar Encuestador");
         // addButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY); // Estilo opcional
         addButton.addClickListener(e -> {
-            clearForm();
+            clearForm(); // Esto llamará a populateForm(null), ocultando el editor.
             this.encuestador = new Encuestador();
-            binder.readBean(this.encuestador);
-            // Opcionalmente, forzar que el panel de edición sea visible y tenga el foco
-            // UI.getCurrent().navigate(EncuestadoresView.class); // Si quieres limpiar la URL también
+            binder.readBean(this.encuestador); // Prepara el formulario para el nuevo encuestador.
+                                             // binder.readBean no debe afectar la visibilidad.
+            if (this.editorLayoutDiv != null) {
+                 this.editorLayoutDiv.setVisible(true); // Mostrar explícitamente el editor para la nueva entidad.
+            }
         });
 
         firstNameFilter = new TextField();
@@ -187,8 +190,8 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
     }
 
     private void createEditorLayout(SplitLayout splitLayout) {
-        Div editorLayoutDiv = new Div();
-        editorLayoutDiv.setClassName("editor-layout");
+        this.editorLayoutDiv = new Div(); // Changed to use the class field
+        this.editorLayoutDiv.setClassName("editor-layout");
 
         Div editorDiv = new Div();
         editorDiv.setClassName("editor");
@@ -201,9 +204,10 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
         formLayout.add(firstName, lastName, ci);
 
         editorDiv.add(formLayout);
-        createButtonLayout(editorLayoutDiv);
+        createButtonLayout(this.editorLayoutDiv);
 
-        splitLayout.addToSecondary(editorLayoutDiv);
+        splitLayout.addToSecondary(this.editorLayoutDiv);
+        this.editorLayoutDiv.setVisible(false); // Set initial visibility
     }
 
     private void createButtonLayout(Div editorLayoutDiv) {
@@ -247,6 +251,8 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
     private void populateForm(Encuestador value) {
         this.encuestador = value;
         binder.readBean(this.encuestador);
-
+        if (this.editorLayoutDiv != null) {
+            this.editorLayoutDiv.setVisible(value != null);
+        }
     }
 }

--- a/src/main/java/uy/com/bay/cruds/views/proyectos/ProyectosView.java
+++ b/src/main/java/uy/com/bay/cruds/views/proyectos/ProyectosView.java
@@ -61,6 +61,7 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
     private final BeanValidationBinder<Proyecto> binder;
 
     private Proyecto proyecto;
+    private Div editorLayoutDiv; // Added field declaration
 
     private final ProyectoService proyectoService;
 
@@ -77,6 +78,9 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
             clearForm();
             this.proyecto = new Proyecto();
             binder.readBean(this.proyecto);
+            if (this.editorLayoutDiv != null) {
+                 this.editorLayoutDiv.setVisible(true);
+            }
         });
 
         nameFilter = new TextField();
@@ -207,8 +211,8 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
     }
 
     private void createEditorLayout(SplitLayout splitLayout) {
-        Div editorLayoutDiv = new Div();
-        editorLayoutDiv.setClassName("editor-layout");
+        this.editorLayoutDiv = new Div(); // Changed to use the class field
+        this.editorLayoutDiv.setClassName("editor-layout");
 
         Div editorDiv = new Div();
         editorDiv.setClassName("editor");
@@ -223,9 +227,10 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
         formLayout.add(name, alchemerId, doobloId, odooId, obs);
 
         editorDiv.add(formLayout);
-        createButtonLayout(editorLayoutDiv);
+        createButtonLayout(this.editorLayoutDiv);
 
-        splitLayout.addToSecondary(editorLayoutDiv);
+        splitLayout.addToSecondary(this.editorLayoutDiv);
+        this.editorLayoutDiv.setVisible(false); // Set initial visibility
     }
 
     private void createButtonLayout(Div editorLayoutDiv) {
@@ -263,6 +268,8 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
     private void populateForm(Proyecto value) {
         this.proyecto = value;
         binder.readBean(this.proyecto);
-
+        if (this.editorLayoutDiv != null) {
+            this.editorLayoutDiv.setVisible(value != null);
+        }
     }
 }

--- a/src/main/java/uy/com/bay/cruds/views/useradmin/UserAdminView.java
+++ b/src/main/java/uy/com/bay/cruds/views/useradmin/UserAdminView.java
@@ -63,6 +63,7 @@ public class UserAdminView extends Div implements BeforeEnterObserver {
 	private final BeanValidationBinder<User> binder;
 
 	private User user;
+	private Div editorLayoutDiv; // Added field declaration
 
 	private final UserService userService;
 
@@ -202,8 +203,8 @@ public class UserAdminView extends Div implements BeforeEnterObserver {
 	}
 
 	private void createEditorLayout(SplitLayout splitLayout) {
-		Div editorLayoutDiv = new Div();
-		editorLayoutDiv.setClassName("editor-layout");
+		this.editorLayoutDiv = new Div(); // Changed to use the class field
+		this.editorLayoutDiv.setClassName("editor-layout");
 
 		Div editorDiv = new Div();
 		editorDiv.setClassName("editor");
@@ -215,9 +216,10 @@ public class UserAdminView extends Div implements BeforeEnterObserver {
 		formLayout.add(userName, password, roles);
 
 		editorDiv.add(formLayout);
-		createButtonLayout(editorLayoutDiv);
+		createButtonLayout(this.editorLayoutDiv);
 
-		splitLayout.addToSecondary(editorLayoutDiv);
+		splitLayout.addToSecondary(this.editorLayoutDiv);
+		this.editorLayoutDiv.setVisible(false); // Set initial visibility
 	}
 
 	private void createButtonLayout(Div editorLayoutDiv) {
@@ -255,6 +257,8 @@ public class UserAdminView extends Div implements BeforeEnterObserver {
 	private void populateForm(User value) {
 		this.user = value;
 		binder.readBean(this.user);
-
+		if (this.editorLayoutDiv != null) { // Check if editorLayoutDiv is initialized
+            this.editorLayoutDiv.setVisible(value != null);
+        }
 	}
 }


### PR DESCRIPTION
Se implementó la gestión dinámica de la visibilidad para los paneles de edición (editorLayoutDiv) en las siguientes vistas:
- UserAdminView.java
- EncuestadoresView.java
- ProyectosView.java

Cambios principales en cada vista:
1.  El `editorLayoutDiv` (que contiene el formulario de edición y los botones de guardar/cancelar) se convirtió en un campo de clase.
2.  El panel de edición ahora está oculto por defecto (`setVisible(false)` en la inicialización).
3.  La visibilidad del panel se controla centralmente a través del método `populateForm(Entity value)`, mostrándose solo si `value` no es nulo.
4.  El método `clearForm()` (que llama a `populateForm(null)`) ahora también oculta el panel.
5.  Los botones "Agregar" en `EncuestadoresView` y `ProyectosView` han sido ajustados para mostrar explícitamente el panel de edición después de preparar el formulario para una nueva entidad. En `UserAdminView`, la navegación existente ya maneja esto correctamente a través de `populateForm`.
6.  Los flujos de selección de grid, cancelación y guardado ahora actualizan correctamente la visibilidad del panel.

Esto mejora tu experiencia al mostrar el formulario de edición solo cuando es contextualmente relevante.