### PR TITLE
feat: Añadir funcionalidad de borrado a vistas CRUD

### DIFF
--- a/src/main/java/uy/com/bay/cruds/views/encuestadores/EncuestadoresView.java
+++ b/src/main/java/uy/com/bay/cruds/views/encuestadores/EncuestadoresView.java
@@ -3,6 +3,7 @@ package uy.com.bay.cruds.views.encuestadores;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.confirmdialog.ConfirmDialog; // Added import
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
@@ -51,6 +52,7 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
 
     private final Button cancel = new Button("Cancel");
     private final Button save = new Button("Save");
+    private Button deleteButton; // Added deleteButton declaration
 
     private final BeanValidationBinder<Encuestador> binder;
 
@@ -76,6 +78,37 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
                                              // binder.readBean no debe afectar la visibilidad.
             if (this.editorLayoutDiv != null) {
                  this.editorLayoutDiv.setVisible(true); // Mostrar explícitamente el editor para la nueva entidad.
+            }
+            if (this.deleteButton != null) {
+                this.deleteButton.setEnabled(false);
+            }
+        });
+
+        deleteButton = new Button("Borrar");
+        deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR);
+        deleteButton.setEnabled(false);
+
+        deleteButton.addClickListener(e -> {
+            if (this.encuestador != null && this.encuestador.getId() != null) {
+                ConfirmDialog dialog = new ConfirmDialog(); // Use imported class
+                dialog.setHeader("Confirmar Borrado");
+                dialog.setText("¿Estás seguro de que quieres borrar este encuestador? Esta acción no se puede deshacer.");
+                dialog.setCancelable(true);
+                dialog.setConfirmText("Borrar");
+                dialog.setConfirmButtonTheme("error primary");
+
+                dialog.addConfirmListener(event -> {
+                    try {
+                        encuestadorService.delete(this.encuestador.getId());
+                        clearForm();
+                        refreshGrid();
+                        Notification.show("Encuestador borrado exitosamente.", 3000, Notification.Position.BOTTOM_START);
+                    } catch (Exception ex) {
+                        Notification.show("Error al borrar el encuestador: " + ex.getMessage(), 5000, Notification.Position.MIDDLE)
+                                .addThemeVariants(NotificationVariant.LUMO_ERROR);
+                    }
+                });
+                dialog.open();
             }
         });
 
@@ -215,7 +248,7 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
         buttonLayout.setClassName("button-layout");
         cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
         save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-        buttonLayout.add(save, cancel);
+		buttonLayout.add(save, deleteButton, cancel);
         editorLayoutDiv.add(buttonLayout);
     }
 
@@ -253,6 +286,9 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
         binder.readBean(this.encuestador);
         if (this.editorLayoutDiv != null) {
             this.editorLayoutDiv.setVisible(value != null);
+        }
+        if (this.deleteButton != null) {
+            this.deleteButton.setEnabled(value != null && value.getId() != null);
         }
     }
 }

--- a/src/main/java/uy/com/bay/cruds/views/proyectos/ProyectosView.java
+++ b/src/main/java/uy/com/bay/cruds/views/proyectos/ProyectosView.java
@@ -3,6 +3,7 @@ package uy.com.bay.cruds.views.proyectos;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.confirmdialog.ConfirmDialog; // Added import
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
@@ -57,6 +58,7 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 
     private final Button cancel = new Button("Cancel");
     private final Button save = new Button("Save");
+    private Button deleteButton; // Added deleteButton declaration
 
     private final BeanValidationBinder<Proyecto> binder;
 
@@ -80,6 +82,37 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
             binder.readBean(this.proyecto);
             if (this.editorLayoutDiv != null) {
                  this.editorLayoutDiv.setVisible(true);
+            }
+            if (this.deleteButton != null) {
+                this.deleteButton.setEnabled(false);
+            }
+        });
+
+        deleteButton = new Button("Borrar");
+        deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR);
+        deleteButton.setEnabled(false);
+
+        deleteButton.addClickListener(e -> {
+            if (this.proyecto != null && this.proyecto.getId() != null) {
+                ConfirmDialog dialog = new ConfirmDialog(); // Use imported class
+                dialog.setHeader("Confirmar Borrado");
+                dialog.setText("¿Estás seguro de que quieres borrar este proyecto? Esta acción no se puede deshacer.");
+                dialog.setCancelable(true);
+                dialog.setConfirmText("Borrar");
+                dialog.setConfirmButtonTheme("error primary");
+
+                dialog.addConfirmListener(event -> {
+                    try {
+                        proyectoService.delete(this.proyecto.getId());
+                        clearForm();
+                        refreshGrid();
+                        Notification.show("Proyecto borrado exitosamente.", 3000, Notification.Position.BOTTOM_START);
+                    } catch (Exception ex) {
+                        Notification.show("Error al borrar el proyecto: " + ex.getMessage(), 5000, Notification.Position.MIDDLE)
+                                .addThemeVariants(NotificationVariant.LUMO_ERROR);
+                    }
+                });
+                dialog.open();
             }
         });
 
@@ -238,7 +271,7 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
         buttonLayout.setClassName("button-layout");
         cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
         save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-        buttonLayout.add(save, cancel);
+		buttonLayout.add(save, deleteButton, cancel);
         editorLayoutDiv.add(buttonLayout);
     }
 
@@ -270,6 +303,9 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
         binder.readBean(this.proyecto);
         if (this.editorLayoutDiv != null) {
             this.editorLayoutDiv.setVisible(value != null);
+        }
+        if (this.deleteButton != null) {
+            this.deleteButton.setEnabled(value != null && value.getId() != null);
         }
     }
 }


### PR DESCRIPTION
Se implementó un botón "Borrar" con diálogo de confirmación en los paneles de edición de las siguientes vistas:

- `UserAdminView.java`
- `EncuestadoresView.java`
- `ProyectosView.java`

Características comunes implementadas en cada vista:
1.  Se añadió un nuevo botón "Borrar" al layout de botones del editor, estilizado con `ButtonVariant.LUMO_ERROR`.
2.  El botón "Borrar" se habilita solo cuando se está editando una entidad existente (que ya tiene un ID) y se deshabilita al crear una nueva entidad o cuando el formulario está limpio.
3.  Al hacer clic en "Borrar", se muestra un `ConfirmDialog` de Vaadin pidiendo tu confirmación.
4.  Si confirmas, se llama al método `delete()` del servicio correspondiente.
5.  Tras un borrado exitoso, el formulario se limpia, el grid se refresca, el panel de edición se oculta y se muestra una notificación de éxito.
6.  Se muestran notificaciones de error si el proceso de borrado falla.