### PR TITLE
Fix: Resolve NullPointerException in UserAdminView constructor

### DIFF
--- a/src/main/java/uy/com/bay/cruds/views/useradmin/UserAdminView.java
+++ b/src/main/java/uy/com/bay/cruds/views/useradmin/UserAdminView.java
@@ -146,34 +146,6 @@ public class UserAdminView extends Div implements BeforeEnterObserver {
 	}
 
 	private void setupButtonListeners() {
-	    deleteButton.addClickListener(e -> {
-            if (this.user != null && this.user.getId() != null) {
-                ConfirmDialog dialog = new ConfirmDialog();
-                dialog.setHeader("Confirmar Borrado");
-                dialog.setText("¿Estás seguro de que quieres borrar este usuario? Esta acción no se puede deshacer.");
-                dialog.setCancelable(true);
-                dialog.setConfirmText("Borrar");
-                dialog.setConfirmButtonTheme("error primary");
-
-                dialog.addConfirmListener(event -> {
-                    try {
-                        userService.delete(this.user.getId());
-                        clearForm();
-                        refreshGrid();
-                        Notification.show("Usuario borrado exitosamente.", 3000, Notification.Position.BOTTOM_START);
-                    } catch (Exception ex) {
-                        Notification.show("Error al borrar el usuario: " + ex.getMessage(), 5000, Notification.Position.MIDDLE)
-                                .addThemeVariants(NotificationVariant.LUMO_ERROR);
-                    }
-                });
-                dialog.open();
-            }
-        });
-
-		deleteButton = new Button("Borrar");
-        deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR);
-        deleteButton.setEnabled(false);
-
         deleteButton.addClickListener(e -> {
             if (this.user != null && this.user.getId() != null) {
                 ConfirmDialog dialog = new ConfirmDialog(); // Use imported class


### PR DESCRIPTION
A NullPointerException occurred during the instantiation of UserAdminView, originating from the createButtonLayout method when adding components to a HorizontalLayout. This was due to a problematic initialization lifecycle of the `deleteButton`.

This commit refactors the UserAdminView class to:
- Ensure `deleteButton` is initialized only once in the constructor.
- Remove a redundant re-initialization of `deleteButton` from the `setupButtonListeners()` method.
- Consolidate duplicated click listener logic for `deleteButton` into a single, clear block.

These changes simplify the component lifecycle, make the code easier to understand, and resolve the NullPointerException, allowing the UserAdminView bean to be created successfully.