### PR TITLE
feat: Implement Odoo integration using Apache XML-RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,27 @@ Once the Docker image is correctly built, you can test it locally using
 ```
 docker run -p 8080:8080 cruds:latest
 ```
+
+## Scheduled Tasks
+
+### Odoo Project Synchronization
+
+The application includes a scheduled task (`OdooProjectSyncTask`) that runs every hour to fetch projects from an Odoo instance and save new ones into the local database.
+
+To enable this functionality, you need to configure the Odoo connection details in `src/main/resources/application.properties`:
+
+```properties
+# ODOO Configuration for Hourly Project Sync
+# These properties are used by the OdooProjectSyncTask to connect to your Odoo instance.
+# Ensure these are correctly set for the OdooProjectSyncTask to function.
+# odoo.url: The full URL of your Odoo instance (e.g., http://localhost:8069).
+# odoo.db: The name of your Odoo database.
+# odoo.username: The username for connecting to Odoo.
+# odoo.password: The API key or password for the Odoo user.
+odoo.url=your_odoo_instance_url
+odoo.db=your_odoo_database
+odoo.username=your_odoo_username
+odoo.password=your_odoo_api_key_or_password
+```
+
+This task interacts with Odoo using XML-RPC, leveraging the Apache XML-RPC client library (`org.apache.xmlrpc:xmlrpc-client`) which is included in `pom.xml`.

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,16 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.xmlrpc</groupId>
+            <artifactId>xmlrpc-client</artifactId>
+            <version>3.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlrpc</groupId>
+            <artifactId>xmlrpc-common</artifactId>
+            <version>3.1.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <optional>true</optional>

--- a/src/main/java/uy/com/bay/cruds/Application.java
+++ b/src/main/java/uy/com/bay/cruds/Application.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.sql.init.SqlDataSourceScriptDatabaseInitializer;
 import org.springframework.boot.autoconfigure.sql.init.SqlInitializationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling; // Import this
 import uy.com.bay.cruds.data.SamplePersonRepository;
 
 /**
@@ -19,6 +20,7 @@ import uy.com.bay.cruds.data.SamplePersonRepository;
  */
 @SpringBootApplication
 @Theme(value = "cruds")
+@EnableScheduling // Add this annotation
 public class Application implements AppShellConfigurator {
 
     public static void main(String[] args) {

--- a/src/main/java/uy/com/bay/cruds/config/OdooConfig.java
+++ b/src/main/java/uy/com/bay/cruds/config/OdooConfig.java
@@ -1,0 +1,47 @@
+package uy.com.bay.cruds.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "odoo")
+public class OdooConfig {
+
+    private String url;
+    private String db;
+    private String username;
+    private String password;
+
+    // Getters
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getDb() {
+        return db;
+    }
+
+    public void setDb(String db) {
+        this.db = db;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/uy/com/bay/cruds/services/OdooService.java
+++ b/src/main/java/uy/com/bay/cruds/services/OdooService.java
@@ -1,0 +1,135 @@
+package uy.com.bay.cruds.services;
+
+import uy.com.bay.cruds.config.OdooConfig;
+import org.apache.xmlrpc.XmlRpcException;
+import org.apache.xmlrpc.client.XmlRpcClient;
+import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+// java.util.Vector is not directly used in the provided code, so I'm omitting it for now.
+// If it's needed by a dependency or a future version, it can be added.
+
+@Service
+public class OdooService {
+
+    private static final Logger logger = LoggerFactory.getLogger(OdooService.class);
+    private final OdooConfig odooConfig;
+    private XmlRpcClient objectClient; // For model operations
+    private XmlRpcClient commonClient; // For authentication
+
+    public OdooService(OdooConfig odooConfig) {
+        this.odooConfig = odooConfig;
+        try {
+            XmlRpcClientConfigImpl commonConfig = new XmlRpcClientConfigImpl();
+            commonConfig.setServerURL(new URL(odooConfig.getUrl() + "/xmlrpc/2/common"));
+            commonClient = new XmlRpcClient();
+            commonClient.setConfig(commonConfig);
+            // It's good practice to set connection and read timeouts
+            // commonConfig.setConnectionTimeout(60 * 1000); // 60 seconds
+            // commonConfig.setReplyTimeout(60 * 1000);     // 60 seconds
+
+
+            XmlRpcClientConfigImpl objectConfig = new XmlRpcClientConfigImpl();
+            objectConfig.setServerURL(new URL(odooConfig.getUrl() + "/xmlrpc/2/object"));
+            objectClient = new XmlRpcClient();
+            objectClient.setConfig(objectConfig);
+            // It's good practice to set connection and read timeouts
+            // objectConfig.setConnectionTimeout(60 * 1000); // 60 seconds
+            // objectConfig.setReplyTimeout(60 * 1000);     // 60 seconds
+
+
+        } catch (MalformedURLException e) {
+            logger.error("Malformed Odoo URL: {}", odooConfig.getUrl(), e);
+            // Consider how to handle this state - perhaps the service should not be usable.
+            // For now, subsequent calls will likely fail if clients are null.
+            throw new RuntimeException("Error initializing Odoo XML-RPC client: Invalid URL", e);
+        }
+    }
+
+    private Integer authenticate() throws XmlRpcException {
+        if (commonClient == null) {
+            logger.error("Odoo common client not initialized. Cannot authenticate.");
+            throw new IllegalStateException("Odoo common client not initialized.");
+        }
+        Object result = commonClient.execute("authenticate", Arrays.asList(
+                odooConfig.getDb(),
+                odooConfig.getUsername(),
+                odooConfig.getPassword(),
+                Collections.emptyMap()
+        ));
+        if (result instanceof Integer) {
+            Integer uid = (Integer) result;
+            if (uid != 0) { // Odoo returns 0 or false for failed login, uid > 0 for success
+                 logger.info("Successfully authenticated with Odoo. UID: {}", uid);
+                return uid;
+            }
+        }
+        logger.error("Odoo authentication failed. Result: {}. Check credentials, DB name, and Odoo URL.", result);
+        return null; // Or throw a specific authentication exception
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Map<String, Object>> getOdooProjects() {
+        if (objectClient == null) {
+            logger.error("Odoo object client not initialized. Cannot fetch projects.");
+            return Collections.emptyList();
+        }
+        try {
+            Integer uid = authenticate();
+            if (uid == null) {
+                logger.error("Cannot fetch projects: Authentication failed.");
+                return Collections.emptyList();
+            }
+
+            List<String> fieldsToFetch = Arrays.asList("id", "name");
+            List<Object> domain = Collections.emptyList(); // Fetch all projects
+
+            HashMap<String, Object> keywordArgs = new HashMap<>();
+            keywordArgs.put("fields", fieldsToFetch);
+            // keywordArgs.put("limit", 10); // Optional: for pagination
+            // keywordArgs.put("offset", 0); // Optional: for pagination
+
+            Object[] params = new Object[]{
+                    odooConfig.getDb(),
+                    uid,
+                    odooConfig.getPassword(),
+                    "project.project", // Odoo model name for projects
+                    "search_read",     // Method to call
+                    Collections.singletonList(domain),
+                    keywordArgs
+            };
+
+            logger.info("Executing Odoo search_read on 'project.project' with fields: {}", fieldsToFetch);
+            Object[] projectsRaw = (Object[]) objectClient.execute("execute_kw", params);
+
+            List<Map<String, Object>> projectsList = new ArrayList<>();
+            for (Object projectObj : projectsRaw) {
+                if (projectObj instanceof Map) {
+                    projectsList.add((Map<String, Object>) projectObj);
+                } else {
+                    logger.warn("Received an object that is not a Map from Odoo: {}", projectObj);
+                }
+            }
+            logger.info("Successfully fetched {} projects from Odoo.", projectsList.size());
+            return projectsList;
+
+        } catch (XmlRpcException e) {
+            logger.error("XmlRpcException while fetching projects from Odoo: {}. Check Odoo XML-RPC endpoint and network.", e.getMessage(), e);
+        } catch (ClassCastException e) {
+            logger.error("ClassCastException while processing Odoo response. Unexpected data structure: {}", e.getMessage(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected exception while fetching projects from Odoo: {}", e.getMessage(), e);
+        }
+        return Collections.emptyList(); // Return empty list in case of any error
+    }
+}

--- a/src/main/java/uy/com/bay/cruds/tasks/OdooProjectSyncTask.java
+++ b/src/main/java/uy/com/bay/cruds/tasks/OdooProjectSyncTask.java
@@ -1,0 +1,86 @@
+package uy.com.bay.cruds.tasks;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import uy.com.bay.cruds.data.Proyecto;
+import uy.com.bay.cruds.services.OdooService;
+import uy.com.bay.cruds.services.ProyectoService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class OdooProjectSyncTask {
+
+    private final OdooService odooService;
+    private final ProyectoService proyectoService;
+
+    public OdooProjectSyncTask(OdooService odooService, ProyectoService proyectoService) {
+        this.odooService = odooService;
+        this.proyectoService = proyectoService;
+    }
+
+    @Scheduled(cron = "0 0 * * * ?") // Runs every hour at the beginning of the hour
+    // For testing, you might use a more frequent cron like "*/30 * * * * ?" (every 30 seconds)
+    // @Scheduled(cron = "*/30 * * * * ?")
+    public void syncOdooProjects() {
+        System.out.println("Starting Odoo Project Sync Task...");
+
+        List<Map<String, Object>> odooProjects = odooService.getOdooProjects();
+        if (odooProjects.isEmpty()) {
+            System.out.println("No projects fetched from Odoo. Sync task finished.");
+            return;
+        }
+
+        List<Proyecto> existingProyectos = proyectoService.findAll();
+        Set<String> existingOdooIds = existingProyectos.stream()
+                                                     .map(Proyecto::getOdooId)
+                                                     .filter(id -> id != null && !id.isEmpty())
+                                                     .collect(Collectors.toSet());
+
+        int newProjectsCount = 0;
+        for (Map<String, Object> odooProjectMap : odooProjects) {
+            // Assuming Odoo project map contains "id" as the Odoo ID and "name" as the project name.
+            // These keys might need adjustment based on the actual data from OdooService.
+            Object odooIdObj = odooProjectMap.get("id");
+            String odooId = null;
+            if (odooIdObj != null) {
+                odooId = String.valueOf(odooIdObj); // Convert to String, ensure it's not null
+            }
+
+            if (odooId == null || odooId.trim().isEmpty()) {
+                System.out.println("Skipping Odoo project with null or empty ID.");
+                continue;
+            }
+
+            if (!existingOdooIds.contains(odooId)) {
+                Proyecto newProyecto = new Proyecto();
+                newProyecto.setOdooId(odooId);
+
+                Object nameObj = odooProjectMap.get("name");
+                if (nameObj != null) {
+                    newProyecto.setName(String.valueOf(nameObj));
+                } else {
+                    newProyecto.setName("Default Name - ID: " + odooId); // Or handle as an error
+                }
+
+                // Map other fields as necessary from odooProjectMap to newProyecto
+                // For example:
+                // String description = (String) odooProjectMap.get("description");
+                // newProyecto.setObs(description);
+
+                proyectoService.save(newProyecto);
+                newProjectsCount++;
+                System.out.println("Saved new project: " + newProyecto.getName() + " (Odoo ID: " + odooId + ")");
+            }
+        }
+
+        if (newProjectsCount > 0) {
+            System.out.println("Odoo Project Sync Task finished. Added " + newProjectsCount + " new project(s).");
+        } else {
+            System.out.println("Odoo Project Sync Task finished. No new projects to add.");
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,15 @@ spring.jpa.hibernate.ddl-auto = update
 vaadin.allowed-packages = com.vaadin,org.vaadin,com.flowingcode,uy.com.bay.cruds
 spring.jpa.defer-datasource-initialization = true
 spring.sql.init.mode = always
+
+# ODOO Configuration for Hourly Project Sync
+# These properties are used by the OdooProjectSyncTask to connect to your Odoo instance.
+# Ensure these are correctly set for the OdooProjectSyncTask to function.
+# odoo.url: The full URL of your Odoo instance (e.g., http://localhost:8069).
+# odoo.db: The name of your Odoo database.
+# odoo.username: The username for connecting to Odoo.
+# odoo.password: The API key or password for the Odoo user.
+odoo.url=your_odoo_instance_url
+odoo.db=your_odoo_database
+odoo.username=your_odoo_username
+odoo.password=your_odoo_api_key_or_password

--- a/src/test/java/uy/com/bay/cruds/services/OdooServiceTest.java
+++ b/src/test/java/uy/com/bay/cruds/services/OdooServiceTest.java
@@ -1,0 +1,77 @@
+package uy.com.bay.cruds.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+
+// Imports for XmlRpcClient, MalformedURLException etc. if we were to mock them
+import uy.com.bay.cruds.config.OdooConfig;
+import java.net.MalformedURLException; // Keep for existing test
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT) // Use lenient strictness to avoid UnnecessaryStubbingException for now
+public class OdooServiceTest {
+
+    @Mock
+    private OdooConfig odooConfigMock;
+
+    // OdooService instance will be created directly in tests for now,
+    // as injecting mocks for its internal XmlRpcClients is complex without refactoring.
+    private OdooService odooService;
+
+    @BeforeEach
+    void setUp() {
+        // No default stubbings here to avoid UnnecessaryStubbingException.
+        // Specific mocks will be set in each test method.
+    }
+
+    @Test
+    void getOdooProjects_whenOdooUrlIsMalformed_thenThrowsRuntimeExceptionDuringConstruction() {
+        // Specific mock for this test case
+        when(odooConfigMock.getUrl()).thenReturn("bad_url-causes_malformed_url_exception");
+        // No need to mock getDb, getUsername, getPassword as the constructor should fail before using them.
+
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            odooService = new OdooService(odooConfigMock);
+        });
+        assertTrue(exception.getMessage().contains("Error initializing Odoo XML-RPC client: Invalid URL"));
+    }
+
+    @Test
+    void getOdooProjects_whenConfigIsValidButConnectionFails_returnsEmptyList() {
+        // Setup mocks required for this test case for OdooService constructor to pass
+        when(odooConfigMock.getUrl()).thenReturn("http://valid-but-likely-unreachable-url.com");
+        // Mocks for getDb, getUsername, getPassword are needed if the constructor or authenticate() is called.
+        // The new OdooService implementation calls these in authenticate() if the URL is valid.
+        when(odooConfigMock.getDb()).thenReturn("test_db");
+        when(odooConfigMock.getUsername()).thenReturn("test_user");
+        when(odooConfigMock.getPassword()).thenReturn("test_pass");
+
+        odooService = new OdooService(odooConfigMock); // Constructor should pass
+
+        List<Map<String, Object>> projects = odooService.getOdooProjects();
+        assertNotNull(projects, "Project list should not be null, even on failure.");
+        assertTrue(projects.isEmpty(), "Expected empty list when Odoo connection or authentication fails");
+    }
+
+    // To truly test the successful data transformation logic within getOdooProjects,
+    // OdooService would need to be refactored to allow injection of mocked XmlRpcClient
+    // instances (e.g., via constructor injection or setters).
+    // Without that, testing the success path of XML-RPC calls at a unit level
+    // would require more advanced mocking tools like PowerMockito or a test-specific
+    // subclassing approach, which are beyond the scope of this current setup.
+    // The current tests focus on construction-time errors (bad URL) and runtime
+    // connection/authentication failures leading to an empty project list.
+    // Full validation of Odoo interaction logic will rely on integration testing (Step 6)
+    // or manual testing with actual Odoo credentials.
+}

--- a/src/test/java/uy/com/bay/cruds/tasks/OdooProjectSyncTaskTest.java
+++ b/src/test/java/uy/com/bay/cruds/tasks/OdooProjectSyncTaskTest.java
@@ -1,0 +1,148 @@
+package uy.com.bay.cruds.tasks;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uy.com.bay.cruds.data.Proyecto;
+import uy.com.bay.cruds.services.OdooService;
+import uy.com.bay.cruds.services.ProyectoService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class OdooProjectSyncTaskTest {
+
+    @Mock
+    private OdooService odooService;
+
+    @Mock
+    private ProyectoService proyectoService;
+
+    @InjectMocks
+    private OdooProjectSyncTask odooProjectSyncTask;
+
+    private List<Map<String, Object>> odooProjectsList;
+    private List<Proyecto> existingProyectosList;
+
+    @BeforeEach
+    void setUp() {
+        odooProjectsList = new ArrayList<>();
+        existingProyectosList = new ArrayList<>();
+    }
+
+    @Test
+    void syncOdooProjects_whenNoOdooProjects_thenNoNewProjectsSaved() {
+        when(odooService.getOdooProjects()).thenReturn(Collections.emptyList());
+
+        odooProjectSyncTask.syncOdooProjects();
+
+        verify(proyectoService, never()).save(any(Proyecto.class));
+    }
+
+    @Test
+    void syncOdooProjects_whenNewProjectsFromOdoo_thenNewProjectsAreSaved() {
+        Map<String, Object> newOdooProject = new HashMap<>();
+        newOdooProject.put("id", "odoo123");
+        newOdooProject.put("name", "New Odoo Project");
+        odooProjectsList.add(newOdooProject);
+
+        when(odooService.getOdooProjects()).thenReturn(odooProjectsList);
+        when(proyectoService.findAll()).thenReturn(Collections.emptyList());
+        // Mock the save operation to return the saved entity, if needed by other logic not present here
+        when(proyectoService.save(any(Proyecto.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+
+        odooProjectSyncTask.syncOdooProjects();
+
+        verify(proyectoService, times(1)).save(argThat(p -> "odoo123".equals(p.getOdooId()) && "New Odoo Project".equals(p.getName())));
+    }
+
+    @Test
+    void syncOdooProjects_whenSomeNewAndSomeExistingProjects_thenOnlyNewAreSaved() {
+        // Existing project
+        Proyecto existingProyecto = new Proyecto();
+        existingProyecto.setOdooId("odooExisting");
+        existingProyecto.setName("Existing Project");
+        existingProyectosList.add(existingProyecto);
+
+        Map<String, Object> odooProjectExisting = new HashMap<>();
+        odooProjectExisting.put("id", "odooExisting");
+        odooProjectExisting.put("name", "Existing Project From Odoo"); // Name might differ
+        odooProjectsList.add(odooProjectExisting);
+
+        Map<String, Object> odooProjectNew = new HashMap<>();
+        odooProjectNew.put("id", "odooNew123");
+        odooProjectNew.put("name", "Another New Project");
+        odooProjectsList.add(odooProjectNew);
+
+        when(odooService.getOdooProjects()).thenReturn(odooProjectsList);
+        when(proyectoService.findAll()).thenReturn(existingProyectosList);
+        when(proyectoService.save(any(Proyecto.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        odooProjectSyncTask.syncOdooProjects();
+
+        verify(proyectoService, times(1)).save(any(Proyecto.class));
+        verify(proyectoService, times(1)).save(argThat(p -> "odooNew123".equals(p.getOdooId())));
+        verify(proyectoService, never()).save(argThat(p -> "odooExisting".equals(p.getOdooId())));
+    }
+
+
+    @Test
+    void syncOdooProjects_whenExistingProjectsFromOdoo_thenNoNewProjectsAreSaved() {
+        Map<String, Object> existingOdooProject = new HashMap<>();
+        existingOdooProject.put("id", "odoo456");
+        existingOdooProject.put("name", "Existing Odoo Project");
+        odooProjectsList.add(existingOdooProject);
+
+        Proyecto existingLocalProyecto = new Proyecto();
+        existingLocalProyecto.setOdooId("odoo456");
+        existingLocalProyecto.setName("Existing Local Project");
+        existingProyectosList.add(existingLocalProyecto);
+
+        when(odooService.getOdooProjects()).thenReturn(odooProjectsList);
+        when(proyectoService.findAll()).thenReturn(existingProyectosList);
+
+        odooProjectSyncTask.syncOdooProjects();
+
+        verify(proyectoService, never()).save(any(Proyecto.class));
+    }
+
+    @Test
+    void syncOdooProjects_whenOdooProjectHasNullId_thenProjectIsSkipped() {
+        Map<String, Object> projectWithNullId = new HashMap<>();
+        projectWithNullId.put("id", null);
+        projectWithNullId.put("name", "Project With Null ID");
+        odooProjectsList.add(projectWithNullId);
+
+        when(odooService.getOdooProjects()).thenReturn(odooProjectsList);
+        // No need to mock findAll or save if it's skipped before that
+
+        odooProjectSyncTask.syncOdooProjects();
+
+        verify(proyectoService, never()).save(any(Proyecto.class));
+    }
+
+    @Test
+    void syncOdooProjects_whenOdooProjectHasEmptyId_thenProjectIsSkipped() {
+        Map<String, Object> projectWithEmptyId = new HashMap<>();
+        projectWithEmptyId.put("id", "");
+        projectWithEmptyId.put("name", "Project With Empty ID");
+        odooProjectsList.add(projectWithEmptyId);
+
+        when(odooService.getOdooProjects()).thenReturn(odooProjectsList);
+
+        odooProjectSyncTask.syncOdooProjects();
+
+        verify(proyectoService, never()).save(any(Proyecto.class));
+    }
+
+}


### PR DESCRIPTION
This commit finalizes the Odoo integration by implementing the communication layer in `OdooService.java` using Apache XML-RPC. The previous placeholder and commented-out high-level client library have been replaced.

Key changes:
- Added `org.apache.xmlrpc:xmlrpc-client` and `org.apache.xmlrpc:xmlrpc-common` dependencies to `pom.xml`.
- Removed the previous non-functional Odoo client dependency.
- Re-implemented `OdooService.java` to:
    - Initialize XML-RPC clients for Odoo's common and object endpoints.
    - Authenticate against Odoo using configured credentials to obtain a UID.
    - Fetch project data (id, name) from the `project.project` model via the `search_read` method using XML-RPC.
    - Include error handling and logging for the communication process.
- Updated unit tests for `OdooService.java` to cover error scenarios with the XML-RPC setup.
- Updated `README.md` to accurately reflect that Odoo communication is handled via Apache XML-RPC.

The scheduled task `OdooProjectSyncTask` now has a fully functional service to retrieve project data from Odoo, pending your configuration of Odoo credentials and endpoint for end-to-end testing.