### PR TITLE
Fix: Add logging for Odoo XML-RPC endpoint URLs

### DIFF
--- a/src/main/java/uy/com/bay/cruds/services/OdooService.java
+++ b/src/main/java/uy/com/bay/cruds/services/OdooService.java
@@ -32,6 +32,7 @@ public class OdooService {
         try {
             XmlRpcClientConfigImpl commonConfig = new XmlRpcClientConfigImpl();
             commonConfig.setServerURL(new URL(odooConfig.getUrl() + "/xmlrpc/2/common"));
+            logger.info("Odoo Common API URL configured: {}", commonConfig.getServerURL());
             commonClient = new XmlRpcClient();
             commonClient.setConfig(commonConfig);
             // It's good practice to set connection and read timeouts
@@ -41,6 +42,7 @@ public class OdooService {
 
             XmlRpcClientConfigImpl objectConfig = new XmlRpcClientConfigImpl();
             objectConfig.setServerURL(new URL(odooConfig.getUrl() + "/xmlrpc/2/object"));
+            logger.info("Odoo Object API URL configured: {}", objectConfig.getServerURL());
             objectClient = new XmlRpcClient();
             objectClient.setConfig(objectConfig);
             // It's good practice to set connection and read timeouts


### PR DESCRIPTION
I've added debug logging to OdooService to record the fully constructed URLs for the common and object XML-RPC endpoints.

This will help you in diagnosing connectivity issues by showing the exact URLs being called during the Odoo integration process. The primary issue of 'NOT FOUND' was due to placeholder configuration values, and you have been instructed to update them.